### PR TITLE
add freeze action to eosio.info and check to eosio.system.setcode

### DIFF
--- a/contracts/eosio.info/include/eosio.info/eosio.info.hpp
+++ b/contracts/eosio.info/include/eosio.info/eosio.info.hpp
@@ -82,6 +82,15 @@ namespace eosio {
           */
          ACTION deluserkey(const name user, const name key);
 
+         /**
+          * Freezes the current code deployed on account, making all future code updates fail
+          *
+          * @param account - the account to freeze
+          *
+          * @pre record must not be present in frozencode table
+          */
+         ACTION freezecode(const name account);
+
 
          static uint128_t composite_key(const uint64_t &x, const uint64_t &y) {
             return (uint128_t{x} << 64) | y;
@@ -130,6 +139,16 @@ namespace eosio {
             uint64_t by_key() const {return key.value; }
          };
 
+         /**
+          * stores contracts that are frozen and cannot be updated anymore
+          */
+         struct [[eosio::table]] frozencode {
+            name      account;
+
+            uint64_t primary_key() const { return account.value; }
+         };
+
+         public:
          typedef eosio::multi_index< "keytypes"_n, keytype > keytypes_table;
          typedef eosio::multi_index< "userverifs"_n, userverif,
             indexed_by<"ckey"_n, const_mem_fun<userverif, uint128_t, &userverif::by_ckey> >, 
@@ -138,6 +157,7 @@ namespace eosio {
          typedef eosio::multi_index< "userkeys"_n, userkey,
             indexed_by<"ckey"_n, const_mem_fun<userkey, uint128_t, &userkey::by_ckey> >, 
             indexed_by<"user"_n, const_mem_fun<userkey, uint64_t, &userkey::by_user> > > userkeys_table;
+         typedef eosio::multi_index< "frozencode"_n, frozencode > frozen_table;
 
    };
 

--- a/contracts/eosio.info/src/eosio.info.cpp
+++ b/contracts/eosio.info/src/eosio.info.cpp
@@ -92,4 +92,17 @@ ACTION info::deluserkey(const name user, const name key)
   idx.erase(itr);
 }
 
+void info::freezecode(const name account)
+{
+  // requires owner permission to freeze code
+  require_auth(permission_level{account, name("owner")});
+
+  frozen_table table(_self, _self.value);
+  auto itr = table.find(account.value);
+
+  check(itr == table.end(), "account already frozen");
+
+  table.emplace(account, [&](auto &t) { t.account = account; });
+}
+
 } /// namespace eosio

--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -11,7 +11,8 @@ add_contract(eosio.system eosio.system
 target_include_directories(eosio.system
    PUBLIC
    ${CMAKE_CURRENT_SOURCE_DIR}/include
-   ${CMAKE_CURRENT_SOURCE_DIR}/../eosio.token/include)
+   ${CMAKE_CURRENT_SOURCE_DIR}/../eosio.token/include
+   ${CMAKE_CURRENT_SOURCE_DIR}/../eosio.info/include)
 
 set_target_properties(eosio.system
    PROPERTIES

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -251,7 +251,7 @@ namespace eosiosystem {
           * @param code - the code content to be set, in the form of a blob binary..
           */
          [[eosio::action]]
-         void setcode( const name& account, uint8_t vmtype, uint8_t vmversion, const std::vector<char>& code ) {}
+         void setcode( const name& account, uint8_t vmtype, uint8_t vmversion, const std::vector<char>& code );
 
          /** @}*/
 

--- a/contracts/eosio.system/src/native.cpp
+++ b/contracts/eosio.system/src/native.cpp
@@ -1,6 +1,7 @@
 #include <eosio.system/native.hpp>
 
 #include <eosio/check.hpp>
+#include <eosio.info/eosio.info.hpp>
 
 namespace eosiosystem {
 
@@ -8,4 +9,9 @@ namespace eosiosystem {
       eosio::check( false, "the onerror action cannot be called directly" );
    }
 
+   void native::setcode( const name& account, uint8_t vmtype, uint8_t vmversion, const std::vector<char>& code ) {
+      // requires FORWARD_SETCODE protocol feature 2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25
+      eosio::info::frozen_table table(name("eosio.info"), name("eosio.info").value);
+      eosio::check(table.find(account.value) == table.end(), "code updates for this account have been frozen");
+   }
 }


### PR DESCRIPTION
# Changelog

- Add `freezecode` action to `eosio.info` contract
- Implement eosio.system's setcode action to throw when setting code on a frozen account.

For the `setcode` action on the system contract to be executed from within `nodeos` (and not just the native `setcode` handler) we need to enable the `FORWARD_SETCODE` protocol feature (hash `2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25`) on the chain